### PR TITLE
move provisioning from  IL1 to IL2

### DIFF
--- a/ipsie-levels.md
+++ b/ipsie-levels.md
@@ -11,8 +11,8 @@ Each level includes the previous level (_e.g._ SL3 includes the requirements of 
 | SL2           |  - MUST terminate sessions at the request of the Identity Service <br> - MUST not accept unsolicited federation assertions| - MUST enforce authentication method requests from Application |
 | SL3           |  - MUST communicate session state changes to Identity Service | - MUST communicate user, session, and device state changes to the Application |
 ||||
-| IL1           | - MUST support Create, Update and Delete of users by the Identity Service prior to sign-in <br>- Local Create, Update, and Delete of users and the Identity Service provided profiles SHALL NOT be allowed <br>| - MUST synchronize provisioned users and their profile data to the Application|
-| IL2           |  - MUST support mapping group claims to application roles and capabilities | - MUST synchronize user group membership claims to Application |
+| IL1           | - MUST support suspend, archive, or delete of users by the Identity Service | - MUST deprovision accounts from the Application|
+| IL2           |  - MUST support create and update of users by the Identity Service prior to sign-in <br>- Local create, Update, and Delete of users and the Identity Service provided profiles SHALL NOT be allowed <br>- MUST support mapping group claims to application roles and capabilities |- MUST synchronize provisioned users and their profile data to the Application <br> - MUST synchronize user group membership claims to Application |
 | IL3           |  - MUST expose application roles to the Identity Service | - MUST consume Application roles and map to users<br> - MUST synchronize user role claims to Application |
 
 -----


### PR DESCRIPTION
focus on the key security benefit of synchronization -- deprovisioning